### PR TITLE
feat: pass to_inline_css options through to parse

### DIFF
--- a/lib/premailex.ex
+++ b/lib/premailex.ex
@@ -16,7 +16,7 @@ defmodule Premailex do
   """
   @spec to_inline_css(String.t(), Keyword.t()) :: String.t()
   def to_inline_css(html, options \\ []) when is_binary(html) do
-    Premailex.HTMLInlineStyles.process(html, options)
+    Premailex.HTMLInlineStyles.process(html, nil, options)
   end
 
   @doc """

--- a/lib/premailex/html_inline_styles.ex
+++ b/lib/premailex/html_inline_styles.ex
@@ -25,7 +25,7 @@ defmodule Premailex.HTMLInlineStyles do
 
   def process(html, css_rule_sets_or_options, options) when is_binary(html) do
     html
-    |> HTMLParser.parse()
+    |> HTMLParser.parse(options)
     |> process(css_rule_sets_or_options, options)
   end
 

--- a/lib/premailex/html_parser.ex
+++ b/lib/premailex/html_parser.ex
@@ -8,7 +8,7 @@ defmodule Premailex.HTMLParser do
   @type html_tree :: tuple() | list()
   @type selector :: binary()
 
-  @callback parse(binary()) :: html_tree()
+  @callback parse(binary(), Keyword.t()) :: html_tree()
   @callback all(html_tree(), selector()) :: [html_tree()]
   @callback filter(html_tree(), selector()) :: [html_tree()]
   @callback to_string(html_tree()) :: binary()
@@ -22,8 +22,8 @@ defmodule Premailex.HTMLParser do
       iex> Premailex.HTMLParser.parse("<html><head></head><body><h1>Title</h1></body></html>")
       {"html", [], [{"head", [], []}, {"body", [], [{"h1", [], ["Title"]}]}]}
   """
-  @spec parse(binary()) :: html_tree()
-  def parse(html), do: parser().parse(html)
+  @spec parse(binary(), Keyword.t()) :: html_tree()
+  def parse(html, options \\ []), do: parser().parse(html, options)
 
   @doc """
   Searches an HTML tree for the selector.


### PR DESCRIPTION
### Description

Allow passing options through to parse so we can pass through context and feature flag behavior in custom HTML parser.