### PR TITLE
chore: move warnings to debug

### DIFF
--- a/lib/premailex/html_inline_styles.ex
+++ b/lib/premailex/html_inline_styles.ex
@@ -113,13 +113,13 @@ defmodule Premailex.HTMLInlineStyles do
   end
 
   defp parse_body({:ok, %{status: status}}, _http_adapter, url) do
-    Logger.warning("Ignoring #{url} styles because received unexpected HTTP status: #{status}")
+    Logger.debug("Ignoring #{url} styles because received unexpected HTTP status: #{status}")
 
     nil
   end
 
   defp parse_body({:error, error}, http_adapter, url) do
-    Logger.warning(
+    Logger.debug(
       "Ignoring #{url} styles because of unexpected error from #{inspect(http_adapter)}:\n\n#{inspect(error)}"
     )
 

--- a/lib/premailex/html_parser/meeseeks.ex
+++ b/lib/premailex/html_parser/meeseeks.ex
@@ -31,7 +31,7 @@ defmodule Premailex.HTMLParser.Meeseeks do
     |> Enum.map(&Meeseeks.tree/1)
   rescue
     e in Meeseeks.Error ->
-      Logger.warning("Meeseeks error: " <> inspect(e))
+      Logger.debug("Meeseeks error: " <> inspect(e))
       []
   end
 


### PR DESCRIPTION
In an effort to quell noisy log lines, I want to propose moving these to debug from warning:

Right now we see LOTs of these:

```
[2025-09-22 14:01:50.454] [warning] Ignoring hbg-brandtps://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap styles because of unexpected error from Premailex.HTTPAdapter.Httpc:
```